### PR TITLE
Adicionar exemplos faltantes

### DIFF
--- a/api/source/includes/_bank_accounts.md
+++ b/api/source/includes/_bank_accounts.md
@@ -89,6 +89,17 @@ bank_account.create
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+BankAccount b = new BankAccount();
+b.Agencia = "0192";
+b.AgenciaDv = "0";
+b.Conta = "03245";
+b.ContaDv = "0";
+b.BankCode = "0341";
+b.DocumentNumber = "26268738888";
+b.LegalName = "API BANK ACCOUNT";
+b.Save();
 ```
 
 Cria uma conta bancária para futuros pagamentos.
@@ -149,6 +160,9 @@ bank_account = PagarMe::BankAccount.find_by_id("4840")
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+var account = PagarMeService.GetDefaultService().BankAccounts.Find("4840");
 ```
 
 Através dessa rota você consegue retornar os dados de uma conta bancária específica.
@@ -205,6 +219,9 @@ bank_accounts = PagarMe::BankAccount.find_by({ bank_code: '237' })
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+var accounts = PagarMeService.GetDefaultService().BankAccounts.FindAll(new BankAccount());
 ```
 
 Através dessa rota você consegue retornar os dados de várias contas bancárias.

--- a/api/source/includes/_bank_accounts.md
+++ b/api/source/includes/_bank_accounts.md
@@ -72,6 +72,20 @@ bank_account.create
 ```
 
 ```php
+<?php
+	require("pagarme-php/Pagarme.php");
+	Pagarme::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
+
+	$account = new Pagarme_Bank_Account(array(
+		"bank_code" => "341",
+		"agencia" => "0932",
+		"agencia_dv" => "5",
+		"conta" => "58054",
+		"conta_dv" => "1",
+		"document_number" => "26268738888",
+		"legal_name" => "API BANK ACCOUNT"
+	));
+	$account->create();
 ```
 
 ```cs
@@ -123,10 +137,15 @@ require 'pagarme'
 
 PagarMe.api_key = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
 
-bank_account = PagarMe::BankAccount.find_by_id("1234")
+bank_account = PagarMe::BankAccount.find_by_id("4840")
 ```
 
 ```php
+<?php
+	require("pagarme-php/Pagarme.php");
+	Pagarme::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
+
+	$bank_account = PagarMe_Bank_Account::findById("4840");
 ```
 
 ```cs
@@ -178,6 +197,11 @@ bank_accounts = PagarMe::BankAccount.find_by({ bank_code: '237' })
 ```
 
 ```php
+<?php
+	require("pagarme-php/Pagarme.php");
+	Pagarme::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
+	
+	$accounts = PagarMe_Bank_Account::all(2, 3);
 ```
 
 ```cs

--- a/api/source/includes/_cards.md
+++ b/api/source/includes/_cards.md
@@ -80,6 +80,15 @@ card.create
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+Card card = new Card();
+card.Number = "4111111111111111";
+card.HolderName = "Jose da Silva";
+card.ExpirationDate = "1022";
+card.Cvv = "123";
+
+card.Save();
 ```
 
 Você pode armazenar os dados do cartão do seu cliente através da rota `/cards`, assim você poderá usar o `id` do objeto gerado para realizar futuras transações, no lugar do `card_hash`.
@@ -138,6 +147,9 @@ card = PagarMe::Card.find_by_id("1234")
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+var card = PagarMeService.GetDefaultService().Cards.Find("card_ci6y37hc00030a416wrxsmzyi");
 ```
 
 Use a rota `/cards/:id` para retornar os dados de um cartão previamente salvo.

--- a/api/source/includes/_cards.md
+++ b/api/source/includes/_cards.md
@@ -77,7 +77,6 @@ card.create
 		"card_expiration_year" => 22,
 		"card_cvv" => "123",
 	));
-?>
 ```
 
 ```cs
@@ -136,7 +135,6 @@ card = PagarMe::Card.find_by_id("1234")
     Pagarme::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
 
 	$card = PagarMe_Card::findById("card_ci6y37hc00030a416wrxsmzyi");
-?>
 ```
 
 ```cs

--- a/api/source/includes/_customers.md
+++ b/api/source/includes/_customers.md
@@ -86,7 +86,6 @@ customer.create
 	));
 
 	$customer->create();
-?>
 ```
 
 ```cs
@@ -173,7 +172,6 @@ customer = PagarMe::Customer.find_by_id(11222)
     Pagarme::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
 
 	$customer = PagarMe_Customer::findById(11222);
-?>
 ```
 
 ```cs
@@ -247,7 +245,6 @@ card = PagarMe::Card.all(1, 2)
     Pagarme::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
 
 	$customers = PagarMe_Customer::all(1, 2);
-?>
 ```
 
 ```cs

--- a/api/source/includes/_plans.md
+++ b/api/source/includes/_plans.md
@@ -85,6 +85,15 @@ plan.create
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+Plan plan = new Plan();
+plan.Amount = 3000;
+plan.TrialDays = 5;
+plan.Days = 30;
+plan.Name = "Plano gold";
+
+plan.Save();
 ```
 
 Cria um plano, onde poderão ser definidos o nome deste, preço, tempo de recorrência, métodos de pagamento, dentre outras opções.
@@ -151,6 +160,9 @@ plan = PagarMe::Plan.find_by_id("13580")
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+var plan = PagarMeService.GetDefaultService().Plans.Find("13850");
 ```
 
 Retorna um plano previamente criado.
@@ -210,6 +222,9 @@ plans = PagarMe::Plan.all(1, 3)
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+var plans = PagarMeService.GetDefaultService().Plans.FindAll(new Plan());
 ```
 
 Retorna todos os planos previamente criados. 

--- a/api/source/includes/_plans.md
+++ b/api/source/includes/_plans.md
@@ -82,7 +82,6 @@ plan.create
 	));
 
 	$plan->create();
-?>
 ```
 
 ```cs
@@ -149,7 +148,6 @@ plan = PagarMe::Plan.find_by_id("13580")
 
 	$plan = PagarMe_Plan::findById("13850");
 
-?>
 ```
 
 ```cs
@@ -209,7 +207,6 @@ plans = PagarMe::Plan.all(1, 3)
 
 	$plans = PagarMe_Plan::all(1, 3);
 
-?>
 ```
 
 ```cs
@@ -306,7 +303,6 @@ plan.save
 	$plan = PagarMe_Plan::findById("12785");
 
 	$plan->setName("plano silver");
-?>
 ```
 
 ```cs

--- a/api/source/includes/_recipients.md
+++ b/api/source/includes/_recipients.md
@@ -84,6 +84,13 @@ curl -X POST https://api.pagar.me/1/recipients \
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+Recipient recipient = new Recipient();
+recipient.TransferInterval = TransferInterval.Weekly;
+recipient.TransferDay = 5;
+recipient.TransferEnabled = true;
+recipient.BankAccount = PagarMeService.GetDefaultService().BankAccounts.Find("4840");
 ```
 
 Com essa rota você consegue criar um recebedor, definindo o período que ele irá receber os pagamentos e qual a conta bancária que será utilizada para envio dos pagamentos.
@@ -155,6 +162,9 @@ curl -X GET https://api.pagar.me/1/recipients \
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+var recipients = PagarMeService.GetDefaultService().Recipients.FindAll(new Recipient());
 ```
 
 Retorna um `Array` de objetos com todos os recebedores criados pela sua companhia.
@@ -273,6 +283,8 @@ curl -X GET https://api.pagar.me/1/recipients/re_ci7nhf1ay0007n016wd5t22nl \
 ```
 
 ```ruby
+
+
 ```
 
 ```php
@@ -284,6 +296,9 @@ curl -X GET https://api.pagar.me/1/recipients/re_ci7nhf1ay0007n016wd5t22nl \
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+var recipient = PagarMeService.GetDefaultService().Recipients.Find("re_ci7nhf1ay0007n016wd5t22nl");
 ```
 
 Retorna um objeto com os dados de um recebedor criado pela sua companhia.

--- a/api/source/includes/_recipients.md
+++ b/api/source/includes/_recipients.md
@@ -68,6 +68,19 @@ curl -X POST https://api.pagar.me/1/recipients \
 ```
 
 ```php
+<?php
+	require("pagarme-php/Pagarme.php");
+	Pagarme::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
+	
+	$recipient = new PagarMe_Recipient(array(
+		"transfer_interval" => "weekly",
+		"transfer_day" => 5,
+		"transfer_enabled" => true,
+		"automatic_anticipation_enabled" => true,
+		"anticipatable_volume_percentage" => 85,
+		"bank_account_id" => 4841
+	));
+	$recipient->create();
 ```
 
 ```cs
@@ -134,6 +147,11 @@ curl -X GET https://api.pagar.me/1/recipients \
 ```
 
 ```php
+<?php
+	require("pagarme-php/Pagarme.php");
+	Pagarme::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
+
+	$recipients = PagarMe_Recipient::all(1, 10);
 ```
 
 ```cs
@@ -258,6 +276,11 @@ curl -X GET https://api.pagar.me/1/recipients/re_ci7nhf1ay0007n016wd5t22nl \
 ```
 
 ```php
+<?php
+	require("pagarme-php/Pagarme.php");
+	Pagarme::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
+	
+	$recipient = PagarMe_Recipient::findById("re_ci7nhf1ay0007n016wd5t22nl");
 ```
 
 ```cs

--- a/api/source/includes/_subscriptions.md
+++ b/api/source/includes/_subscriptions.md
@@ -163,10 +163,22 @@ subscription.create
 		)));
 
 	$subscription->create();
-
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+Subscription subscription = new Subscription();
+subscription.CardNumber = "4901720080344448";
+subscription.CardHolderName = "Jose da Silva";
+subscription.CardExpirationDate = "1215";
+subscription.CardCvv = "123";
+
+Customer customer = new Customer();
+customer.Email = "api@test.com";
+subscription.Customer = customer;
+
+subscription.Save();
 ```
 
 Para efetivamente cobrar seu cliente de forma recorrente, você deve criar uma **assinatura**, que atrelada a um **plano**, conterá os dados de cobrança.
@@ -300,6 +312,9 @@ subscription = PagarMe::Subscription.find_by_id("14858")
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+var subscription = PagarMeService.GetDefaultService().Subscriptions.Find("14858");
 ```
 
 Essa rota é utilizada para retornar os dados de uma determinada assinatura.
@@ -424,6 +439,9 @@ subscriptions = PagarMe::Subscription.all(1, 2)
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+var subscriptions = PagarMeService.GetDefaultService().Subscriptions.FindAll(new Subscription());
 ```
 
 Essa rota é utilizada para retornar os dados de todas assinaturas.

--- a/api/source/includes/_subscriptions.md
+++ b/api/source/includes/_subscriptions.md
@@ -164,7 +164,6 @@ subscription.create
 
 	$subscription->create();
 
-?>
 ```
 
 ```cs
@@ -298,7 +297,6 @@ subscription = PagarMe::Subscription.find_by_id("14858")
     Pagarme::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
 
 	$subscription = PagarMe_Subscription::findById(14858);
-?>
 ```
 
 ```cs
@@ -423,7 +421,6 @@ subscriptions = PagarMe::Subscription.all(1, 2)
     Pagarme::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
 
 	$subscription = PagarMe_Subscription::all(1, 2);
-?>
 ```
 
 ```cs
@@ -636,7 +633,6 @@ subscription.save
 	$subscription->setPaymentMethod("boleto");
 
 	$subscription->save();
-?>
 ```
 
 ```cs
@@ -769,7 +765,6 @@ subscription.cancel
 
 	$subscription = PagarMe_Subscription::findById(14858);
 	$subscription->cancel();
-?>
 ```
 
 ```cs

--- a/api/source/includes/_transactions.md
+++ b/api/source/includes/_transactions.md
@@ -130,7 +130,6 @@ transaction.charge
     ));
 
     $transaction->charge();
-?>
 ```
 
 ```cs
@@ -257,7 +256,6 @@ transaction = PagarMe::Transaction.find_by_id("184270")
     Pagarme::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
 
     $transaction = PagarMe_Transaction::findById("184270");
-?>
 ```
 
 ```cs
@@ -333,7 +331,6 @@ transactions = PagarMe::Transaction.all(3, 3)
     Pagarme::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
 
     $transaction = PagarMe_Transaction::all(3, 3);
-?>
 ```
 
 ```cs
@@ -503,7 +500,6 @@ key = PagarMe::Transaction.generate_card_hash()
     ));
 
     $key = $t->generateCardHash();
-?>
 ```
 
 ```cs
@@ -1225,7 +1221,6 @@ transaction.capture({:amount => 1000})
 	$t->charge();
 
 	$t->capture(3100);
-?>
 ```
 
 ```cs
@@ -1340,7 +1335,6 @@ transaction.refund
 	$t->charge();
 
 	$t->refund();
-?>
 ```
 
 ```cs

--- a/api/source/includes/_transactions.md
+++ b/api/source/includes/_transactions.md
@@ -255,10 +255,13 @@ transaction = PagarMe::Transaction.find_by_id("184270")
 
     Pagarme::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
 
-    $transaction = PagarMe_Transaction::findById("184270");
+    $transaction = PagarMe_Transaction::findById("194351");
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+var transaction = PagarMeService.GetDefaultService().Transactions.Find("194351");
 ```
 
 Retorna os dados de uma transação realizada.
@@ -334,6 +337,9 @@ transactions = PagarMe::Transaction.all(3, 3)
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+var transaction = PagarMeService.GetDefaultService().Transactions.FindAll(new Transaction());
 ```
 
 Retorna um `Array` contendo objetos de transações, ordenadas a partir da transação realizada mais recentemente.
@@ -503,7 +509,6 @@ key = PagarMe::Transaction.generate_card_hash()
 ```
 
 ```cs
-
 ```
 
 Caso você queira/precise criar o `card_hash` manualmente, essa rota deverá ser utilizada para obtenção de uma chave pública de encriptação dos dados do cartão de seu cliente.
@@ -1224,6 +1229,19 @@ transaction.capture({:amount => 1000})
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+Transaction transaction = new Transaction();
+
+transaction.Amount = 3100;
+transaction.CardId = "card_ci6l9fx8f0042rt16rtb477gj";
+transaction.PostbackUrl = "http://requestb.in/pkt7pgpk";
+transaction.Metadata = new Metadata() {
+    IdProduto = 13933139
+};
+transaction.Save();
+
+transaction.Capture(3100);
 ```
 
 Você pode capturar o valor de uma transação após a autorização desta, no prazo máximo de 5 dias após a autorização.
@@ -1338,6 +1356,19 @@ transaction.refund
 ```
 
 ```cs
+PagarMeService.DefaultApiKey = "ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0";
+
+Transaction transaction = new Transaction();
+
+transaction.Amount = 3100;
+transaction.CardId = "card_ci6l9fx8f0042rt16rtb477gj";
+transaction.PostbackUrl = "http://requestb.in/pkt7pgpk";
+transaction.Metadata = new Metadata() {
+    IdProduto = 13933139
+};
+transaction.Save();
+
+transaction.Refund();
 ```
 
 Essa rota é utilizada quando se deseja estornar uma transação, realizada por uma cobrança via cartão de crédito ou boleto bancário.


### PR DESCRIPTION
Esse pull request possui commits que:

1. Adicionam exemplos da biblioteca PHP a `Bank_Account` e `Recipient`.
2. Removem a closing tag de todos os exemplos de PHP, de acordo com as best practices descritas em http://php.net/manual/en/language.basic-syntax.phptags.php.
3. Adicionam exemplos da biblioteca C# a todos os domínios onde foi possível (`BankAccount`, `Card`, `Recipient`, `Subscription`, `Transaction` etc.)