### PR TITLE
Fix typos

### DIFF
--- a/api/source/includes/_transactions.md
+++ b/api/source/includes/_transactions.md
@@ -1828,7 +1828,7 @@ curl -X GET https://api.pagar.me/1/transactions/card_hash_key \
 ```cs
 ```
 
-Para gerarmos o `card_hash`, primeiramente devemos requisitar do servidr a chave pública para criptografarmos nossos dados.
+Para gerarmos o `card_hash`, primeiramente devemos requisitar do servidor a chave pública para criptografarmos nossos dados.
 
 > JSON retornado (exemplo):
 

--- a/api/source/includes/_transactions.md
+++ b/api/source/includes/_transactions.md
@@ -1074,7 +1074,7 @@ curl -X GET https://api.pagar.me/1/transactions/314578/operations \
 ```cs
 ```
 
-Retorna todo o histórico de uma transaçnao, ou seja, toda e qualquer operação que já aconteceu com ela. <br><br>**Ex**: autorização, análise antifraude, captura, estorno, chargeback, emissão de boleto, conciliação, etc.
+Retorna todo o histórico de uma transação, ou seja, toda e qualquer operação que já aconteceu com ela. <br><br>**Ex**: autorização, análise antifraude, captura, estorno, chargeback, emissão de boleto, conciliação, etc.
 
 > JSON Retornado (Exemplo)
 


### PR DESCRIPTION
Fix typo in `transaçnao` (it must be `transação`).
