### PR TITLE
Fixed typo on PHP reference.

### DIFF
--- a/docs/source/transactions.md
+++ b/docs/source/transactions.md
@@ -51,7 +51,7 @@ status = transaction.status # status da transação
 <?php
 	require("pagarme-php/Pagarme.php");
 
-	Pagarme::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
+	PagarMe::setApiKey("ak_test_grXijQ4GicOa2BLGZrDRTR5qNQxJW0");
 
 	$transaction = new PagarMe_Transaction(array(
 		'amount' => 1000,


### PR DESCRIPTION
On https://docs.pagar.me/transactions/:

![realizando-uma-transacao-de-cartao-de-credito](https://cloud.githubusercontent.com/assets/1259313/20367016/cff1a6ce-ac34-11e6-899e-5ea8bb62c31b.jpg)

The correct class name is `PagarMe` instead of `Pagarme`. The typo may cause problems due to the following: if the SDK is installed by the same example in the doc, both names are compatible (`PagarMe` and `Pagarme`), but, if the SDK is installed via Composer, the class `Pagarme` will not be found, resulting in an error.

This pull request aims to change the class name reference by using the most compatible name for both scenarios.
